### PR TITLE
Make zLOG work both with python2 and python3 via six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ probably better off using Python's logging module.""",
       packages=find_packages('src'),
       package_dir={'': 'src'},
 
-      install_requires=['ZConfig >= 2.9.2'],
+      install_requires=['six',
+                        'ZConfig >= 2.9.2'],
       include_package_data=True,
       zip_safe=False,
       )

--- a/src/zLOG/EventLogger.py
+++ b/src/zLOG/EventLogger.py
@@ -20,6 +20,7 @@ This uses Vinay Sajip's PEP 282 logging module.
 __version__='$Revision$'[11:-2]
 
 import logging
+import six
 import time
 
 # XXX Defining custom levels needs to move to
@@ -50,7 +51,7 @@ def log_write(subsystem, severity, summary, detail, error):
 
     if isinstance(error, tuple):
         try:
-            raise error[0], error[1], error[2]
+            six.reraise(error[0], error[1], error[2])
         except:
             pass
 

--- a/src/zLOG/__init__.py
+++ b/src/zLOG/__init__.py
@@ -80,6 +80,7 @@ somewhere else.
 
 from EventLogger import log_write, log_time, severity_string
 from traceback import format_exception
+import six
 
 # Standard severities
 TRACE   = -300
@@ -134,7 +135,7 @@ def LOG(subsystem, severity, summary, detail='', error=None, reraise=None):
     """
     log_write(subsystem, severity, summary, detail, error)
     if reraise and error:
-        raise error[0], error[1], error[2]
+        six.reraise(error[0], error[1], error[2])
 
 _subsystems = []
 def register_subsystem(subsystem):

--- a/src/zLOG/tests/testzLog.py
+++ b/src/zLOG/tests/testzLog.py
@@ -123,7 +123,7 @@ class EventLogTest(unittest.TestCase):
         self.setLog()
         try:
             1 / 0
-        except ZeroDivisionError, err:
+        except ZeroDivisionError as err:
             err = sys.exc_info()
 
         zLOG.LOG("basic", zLOG.INFO, "summary")


### PR DESCRIPTION
Make this package py3 compatible.
